### PR TITLE
CVS-161 グローバルコンフィグを共通化して格納

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -76,7 +76,10 @@ func main() {
 		MaxAge:           24 * time.Hour,
 	}))
 
-	v1Handler := handler.V1Handler{}
+	opts := handler.ServerConfig{
+		StorageDir: os.Getenv("STORAGE_DIR"),
+	}
+	v1Handler := handler.NewV1Handler(opts)
 
 	ginServerOpts := adapters.GinServerOptions{
 		ErrorHandler: middleware.GenericErrorHandler,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"errors"
 	"net/http"
-	"os"
 
 	"github.com/CharVstack/CharV-backend/internal/util"
 	"github.com/CharVstack/CharV-backend/middleware"
@@ -15,13 +14,24 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+type ServerConfig struct {
+	StorageDir string
+}
+
 // V1Handler 引数を返さないので空
-type V1Handler struct{}
+type V1Handler struct {
+	Config ServerConfig
+}
+
+func NewV1Handler(opts ServerConfig) *V1Handler {
+	handler := &V1Handler{}
+	handler.Config = opts
+	return handler
+}
 
 func (v V1Handler) GetApiV1Host(c *gin.Context) {
-	storageDir := os.Getenv("STORAGE_DIR")
 	getHostInfoOpts := host.GetInfoOptions{
-		StorageDir: storageDir,
+		StorageDir: v.Config.StorageDir,
 	}
 	hostInfo, err := host.GetInfo(getHostInfoOpts)
 	if err != nil {


### PR DESCRIPTION
## 概要

グローバルコンフィグをginのstructに格納して参照するように変更。


## 動作テスト方法

N/A

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
