### PR TITLE
CVS-175 vm作成時にsocketが生成されるように更新

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -70,7 +70,7 @@ func (v V1Handler) PostApiV1Vms(c *gin.Context) {
 		return
 	}
 
-	vm, err := qemu.CreateVm(requestBody)
+	vm, err := qemu.CreateVm(requestBody, v.Config.SocketsDir)
 	if err != nil {
 		middleware.GenericErrorHandler(c, err, http.StatusInternalServerError)
 		return

--- a/pkg/qemu/type.go
+++ b/pkg/qemu/type.go
@@ -1,11 +1,15 @@
 package qemu
 
+import "github.com/google/uuid"
+
 type InstallOpts struct {
-	Name   string
-	Memory uint64
-	VCpu   int
-	Image  string
-	Disk   string
+	Name       string
+	Memory     uint64
+	VCpu       int
+	Image      string
+	Disk       string
+	Id         uuid.UUID
+	SocketPath string
 }
 
 type StartOpts struct {


### PR DESCRIPTION
## 概要
vm作成時にsocketが生成されるように更新

## 動作テスト方法

```
possive@charvdev:/var/lib/charVstack/socks$ ls
possive@charvdev:/var/lib/charVstack/socks$ curl -X POST http://localhost:8080/api/v1/vms -H 'content-type: application/json' -d '{"name": "ftest", "vcpu": 1, "memory": 2048}'
{"vm":{"cpu":0,"devices":{"disk":[{"device":"disk","name":"ftestDisk","pool":"default","type":"qcow2"}]},"memory":2048,"metadata":{"api_version":"v1","id":"645edac2-ddab-4220-b591-1fd031b3c696"},"name":"ftest"}}possive@charvdev:/var/lib/charVstack/socks$
possive@charvdev:/var/lib/charVstack/socks$ ls
645edac2-ddab-4220-b591-1fd031b3c696.sock
possive@charvdev:/var/lib/charVstack/socks$ socat - unix-connect:./645edac2-ddab-4220-b591-1fd031b3c696.sock
QEMU 6.2.0 monitor - type 'help' for more information
(qemu) system_powerdown
system_powerdown
(qemu) quit
quit
possive@charvdev:/var/lib/charVstack/socks$ ls
possive@charvdev:/var/lib/charVstack/socks$
```
## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
