### PR TITLE
CVS-137 VMの電源状態の取得

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/google/uuid"
+
 	"github.com/CharVstack/CharV-backend/pkg/qemu"
 	"github.com/CharVstack/CharV-backend/pkg/util"
 
@@ -93,7 +95,7 @@ func (v V1Handler) PatchApiV1VmsVmId(c *gin.Context, vmId openapi_types.UUID) {
 	return
 }
 
-func (v V1Handler) GetApiV1VmsVmIdPower(c *gin.Context, vmId openapi_types.UUID) {
+func (v V1Handler) GetApiV1VmsVmIdPower(c *gin.Context, vmId uuid.UUID) {
 	power, err := qemu.GetVmPower(vmId, v.Config.SocketsDir)
 	if err != nil {
 		middleware.GenericErrorHandler(c, err, http.StatusInternalServerError)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -94,9 +94,15 @@ func (v V1Handler) PatchApiV1VmsVmId(c *gin.Context, vmId openapi_types.UUID) {
 }
 
 func (v V1Handler) GetApiV1VmsVmIdPower(c *gin.Context, vmId openapi_types.UUID) {
-	//TODO implement me
-	middleware.GenericErrorHandler(c, errors.New("implement me"), http.StatusInternalServerError)
-	return
+	power, err := qemu.GetVmPower(vmId, v.Config.SocketsDir)
+	if err != nil {
+		middleware.GenericErrorHandler(c, err, http.StatusInternalServerError)
+		return
+	}
+
+	c.JSON(http.StatusOK, models.GetVMPowerByVMId200Response{
+		VmPower: power,
+	})
 }
 
 func (v V1Handler) PostApiV1VmsVmIdPowerAction(c *gin.Context, vmId openapi_types.UUID, params models.PostApiV1VmsVmIdPowerActionParams) {

--- a/pkg/qemu/vm.go
+++ b/pkg/qemu/vm.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/CharVstack/CharV-backend/pkg/util"
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+
 	"github.com/CharVstack/CharV-backend/domain/models"
 	"github.com/google/uuid"
 	"github.com/mattn/go-shellwords"
@@ -178,4 +181,31 @@ func parse(path string) (models.Vm, error) {
 		return models.Vm{}, err
 	}
 	return machine, nil
+}
+
+func GetVmPower(id openapi_types.UUID, path string) (models.VmPowerInfo, error) {
+	// get all opened sockets
+	sockFiles, err := os.ReadDir(path)
+	if err != nil {
+		return models.VmPowerInfo{}, err
+	}
+	var socks []string
+	for _, v := range sockFiles {
+		socks = append(socks, v.Name()[:36])
+	}
+
+	// try finding the target id
+	i := util.SearchVmId(socks, id)
+	if i != -1 { // found
+		return models.VmPowerInfo{
+			CleanPowerOff: true,
+			State:         "RUNNING",
+		}, nil
+	}
+
+	// not found
+	return models.VmPowerInfo{
+		CleanPowerOff: true,
+		State:         "SHUTDOWN",
+	}, nil
 }

--- a/pkg/qemu/vm.go
+++ b/pkg/qemu/vm.go
@@ -8,10 +8,8 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/CharVstack/CharV-backend/pkg/util"
-	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
-
 	"github.com/CharVstack/CharV-backend/domain/models"
+	"github.com/CharVstack/CharV-backend/pkg/util"
 	"github.com/google/uuid"
 	"github.com/mattn/go-shellwords"
 )
@@ -183,7 +181,7 @@ func parse(path string) (models.Vm, error) {
 	return machine, nil
 }
 
-func GetVmPower(id openapi_types.UUID, path string) (models.VmPowerInfo, error) {
+func GetVmPower(id uuid.UUID, path string) (models.VmPowerInfo, error) {
 	// get all opened sockets
 	sockFiles, err := os.ReadDir(path)
 	if err != nil {

--- a/pkg/qemu/vm_test.go
+++ b/pkg/qemu/vm_test.go
@@ -1,8 +1,12 @@
 package qemu
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/CharVstack/CharV-backend/domain/models"
 	"github.com/google/uuid"
@@ -41,5 +45,61 @@ func TestGetAllVms(t *testing.T) {
 	_, err := getAllVms("../../test/resources/machines/")
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestGetVmPower(t *testing.T) {
+	type args struct {
+		id   types.UUID
+		path string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    models.VmPowerInfo
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "pass01",
+			args: args{
+				id:   uuid.Must(uuid.Parse("0bfb8def-86ed-4b9d-8826-66a6ab1c1491")),
+				path: "../../test/resources/socks",
+			},
+			want: models.VmPowerInfo{
+				CleanPowerOff: true,
+				State:         "RUNNING",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "fail01",
+			args: args{
+				id:   uuid.Must(uuid.Parse("99999999-0000-4444-1111-112233445566")),
+				path: "../../test/resources/socks",
+			},
+			want: models.VmPowerInfo{
+				CleanPowerOff: true,
+				State:         "SHUTDOWN",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "fail02",
+			args: args{
+				id:   uuid.Must(uuid.Parse("99999999-0000-4444-1111-112233445566")),
+				path: "/no/exists/path",
+			},
+			want:    models.VmPowerInfo{},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetVmPower(tt.args.id, tt.args.path)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetVmPower(%v, %v)", tt.args.id, tt.args.path)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "GetVmPower(%v, %v)", tt.args.id, tt.args.path)
+		})
 	}
 }

--- a/pkg/qemu/vm_test.go
+++ b/pkg/qemu/vm_test.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deepmap/oapi-codegen/pkg/types"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/CharVstack/CharV-backend/domain/models"
@@ -50,7 +49,7 @@ func TestGetAllVms(t *testing.T) {
 
 func TestGetVmPower(t *testing.T) {
 	type args struct {
-		id   types.UUID
+		id   uuid.UUID
 		path string
 	}
 	tests := []struct {

--- a/pkg/util/search.go
+++ b/pkg/util/search.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+)
+
+func SearchVmId(socks []string, x openapi_types.UUID) int {
+	for i, v := range socks {
+		if v == x.String() {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/util/search.go
+++ b/pkg/util/search.go
@@ -1,10 +1,10 @@
 package util
 
 import (
-	openapi_types "github.com/deepmap/oapi-codegen/pkg/types"
+	"github.com/google/uuid"
 )
 
-func SearchVmId(socks []string, x openapi_types.UUID) int {
+func SearchVmId(socks []string, x uuid.UUID) int {
 	for i, v := range socks {
 		if v == x.String() {
 			return i


### PR DESCRIPTION
## 概要

VMの電源状態 ( `RUNNING` または `SHUTDOWN` ) の取得機能を追加した

## 動作テスト方法

### 1. テストの作成

関数のテストを作成した

```
/usr/lib/golang/bin/go tool test2json -t /tmp/GoLand/___TestGetVmPower_in_github_com_CharVstack_CharV_backend_pkg_qemu.test -test.v -test.paniconexit0 -test.run ^\QTestGetVmPower\E$
=== RUN   TestGetVmPower
=== RUN   TestGetVmPower/pass01
=== RUN   TestGetVmPower/fail01
=== RUN   TestGetVmPower/fail02
--- PASS: TestGetVmPower (0.00s)
    --- PASS: TestGetVmPower/pass01 (0.00s)
    --- PASS: TestGetVmPower/fail01 (0.00s)
    --- PASS: TestGetVmPower/fail02 (0.00s)
PASS

Process finished with the exit code 0
```

### 2. curl コマンドによるテスト

サーバを立ち上げ、curl コマンドを使って動作確認をした

1. VM が起動しているとき ( ソケットファイルが存在するとき )

```
$ curl localhost:8080/api/v1/vms/0bfb8def-86ed-4b9d-8826-66a6ab1c1491/power | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    55  100    55    0     0  17198      0 --:--:-- --:--:-- --:--:-- 27500
{
  "vm_power": {
    "clean_power_off": true,
    "state": "RUNNING"
  }
}
```

2. VM が停止しているとき ( ソケットファイルが存在しないとき )

```
$ curl localhost:8080/api/v1/vms/99999999-0000-4444-1111-112233445566/power | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    56  100    56    0     0  44129      0 --:--:-- --:--:-- --:--:-- 56000
{
  "vm_power": {
    "clean_power_off": true,
    "state": "SHUTDOWN"
  }
}
```

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
