### PR TITLE
CVS-197 WIP: secrets が読み込めていないのを修正

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,7 @@ jobs:
           cp ./bin/server ~/CharV-backend/charv-backend
 
       - name: Set up environment
-        run : ssh ${{ secret.DEVELOPMENT_SERVER_USER }}@${{ secret.DEVELOPMENT_SERVER_IP }} ~/CharV-backend/init.sh
+        run : ssh ${{ secrets.DEVELOPMENT_SERVER_USER }}@${{ secrets.DEVELOPMENT_SERVER_IP }} ~/CharV-backend/init.sh
 
       - name: Restart server
-        run : ssh ${{ secret.DEVELOPMENT_SERVER_USER }}@${{ secret.DEVELOPMENT_SERVER_IP }} systemctl restart charv@backend.service
+        run : ssh ${{ secrets.DEVELOPMENT_SERVER_USER }}@${{ secrets.DEVELOPMENT_SERVER_IP }} systemctl restart charv@backend.service


### PR DESCRIPTION
## 概要

`secrets` が  `secret` になっていた

## 動作テスト方法

merge して動作テスト

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
