### PR TITLE
CVS-198 `.env` ファイルを引数で読み取るように変更

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"io/fs"
 	"log"
 	"os"
@@ -31,7 +32,12 @@ import (
 var production bool
 
 func init() {
-	err := godotenv.Load("./.env")
+	var (
+		configPath = flag.String("c", "/etc/charv/backend.conf", "backend config file path")
+	)
+	flag.Parse()
+
+	err := godotenv.Load(*configPath)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
## 概要

実行時のコマンドライン引数で `.env` ファイルを指定できるようにした

## 動作テスト方法

引数を指定して実行

```
./bin/server -c .env
```

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
