### PR TITLE
CVS-205 バイナリの転送方法に失敗するバグを修正

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -24,8 +24,8 @@ jobs:
           make build
           cp ./bin/server ~/CharV-backend/charv-backend
 
-      - name: Set up environment
-        run : ~/CharV-backend/init.sh
+      - name: Upload binary
+        run : rsync -e ssh /home/charv/CharV-backend/charv-backend ${{ secrets.DEPLOYMENT_USER }}@${{ secrets.DEPLOYMENT_SERVER }}:/usr/local/bin/charv-backend
 
       - name: Restart server
         run : ssh ${{ secrets.DEPLOYMENT_USER }}@${{ secrets.DEPLOYMENT_SERVER }} systemctl restart charv@backend.service


### PR DESCRIPTION
## 概要

SFTP の `put` コマンドはリモートに転送しようとしているファイルと同名のファイルが存在すると転送に失敗する。

```
Run ~/CharV-backend/init.sh
spawn sftp ***@***
Connected to ***.
sftp> put /home/charv/CharV-backend/charv-backend /usr/local/bin/
Uploading /home/charv/CharV-backend/charv-backend to /usr/local/bin/charv-backend
dest open "/usr/local/bin/charv-backend": Failure

sftp> bye
```

rsync を利用することでバグの修正をした

## 動作テスト方法

merge して動作テスト

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
