### PR TITLE
CVS-245 VM再起動に失敗する不具合の修正

### DIFF
--- a/pkg/qemu/vm.go
+++ b/pkg/qemu/vm.go
@@ -334,7 +334,7 @@ func startVmPower(id uuid.UUID, sockPath string) error {
 		SocketPath: sockPath,
 	}
 
-	tmpl, _ := template.New("install").Parse(`qemu-system-x86_64 -accel kvm -daemonize -display none -name guest={{.Name}} -smp {{.VCpu}} -m {{.Memory}} -drive file=/var/lib/charVstack/images/{{.Disk}}.qcow2,format=qcow2 -drive file=/var/lib/charVstack/bios/bios.bin,format=raw,if=pflash,readonly=on -qmp unix:/{{.SocketPath}}/{{.Id}}.sock,server,nowait`)
+	tmpl, _ := template.New("install").Parse(`qemu-system-x86_64 -accel kvm -daemonize -display none -name guest={{.Name}} -smp {{.VCpu}} -m {{.Memory}} -drive file=/var/lib/charVstack/images/{{.Disk}}.qcow2,format=qcow2 -drive file=/var/lib/charVstack/bios/bios.bin,format=raw,if=pflash,readonly=on -qmp unix:/{{.SocketPath}}/{{.Id}}.sock,server,nowait -vnc unix:/{{.SocketPath}}/vnc-{{.Id}}.sock`)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, StartOpts); err != nil {
 		return err

--- a/pkg/qemu/vm.go
+++ b/pkg/qemu/vm.go
@@ -289,6 +289,9 @@ func downVmPower(id uuid.UUID, sockPath string, action string) (err error) {
 	}
 
 	err = deleteVncSocket(id, sockPath)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/qemu/vm.go
+++ b/pkg/qemu/vm.go
@@ -287,6 +287,9 @@ func downVmPower(id uuid.UUID, sockPath string, action string) (err error) {
 	if err != nil {
 		return err
 	}
+
+	err = deleteVncSocket(id, sockPath)
+
 	return nil
 }
 


### PR DESCRIPTION
## 概要
再起動実施時にVNCソケットが残留してしまう不具合があったためそれの修正

## 動作テスト方修正
サーバで実行し手動テスト

## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
